### PR TITLE
DjinnJS v0.0.4

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.4] - 2019-12-22
+
+### Fixed
+
+-   Removed import statements from Web Workers
+
 ## [0.0.3] - 2019-12-22
 
 ### Added
@@ -40,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     -   Intial DjinnJS compiler scripts
 
 [unreleased]: https://github.com/pageworks/djinnjs/compare/v0.0.2...HEAD
+[0.0.4]: https://github.com/pageworks/djinnjs/compare/v0.0.3...v0.0.4
 [0.0.3]: https://github.com/pageworks/djinnjs/compare/v0.0.2...v0.0.3
 [0.0.2]: https://github.com/pageworks/djinnjs/compare/v0.0.1...v0.0.2
 [0.0.1]: https://github.com/pageworks/djinnjs/releases/tag/v0.0.1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "djinnjs",
-    "version": "0.0.3",
+    "version": "0.0.4",
     "description": "DjinnJS is an ES Module based JavaScript framework using JIT resource fetching, offline first content strategy, context-specific progressive enhancements, and Pjax navigation.",
     "author": "Pageworks",
     "license": "GPL-3.0",

--- a/src/core/broadcast-worker.ts
+++ b/src/core/broadcast-worker.ts
@@ -1,7 +1,5 @@
 /// <reference path="./messages.d.ts" />
 
-import { debug } from './env';
-
 type InboxData = {
     name: string;
     address: number;
@@ -91,9 +89,7 @@ class BroadcastHelper {
                 this.handleUserDeviceInfo(data as UserDeviceInfoMessage);
                 break;
             default:
-                if (debug) {
-                    console.warn(`Unknown broadcast-worker message type: ${data.type}`);
-                }
+                console.warn(`Unknown broadcast-worker message type: ${data.type}`);
                 break;
         }
     }
@@ -179,9 +175,7 @@ class BroadcastHelper {
                 }
             }
         } catch (error) {
-            if (debug) {
-                console.error(error);
-            }
+            console.error(error);
         }
     }
 

--- a/src/core/pjax-worker.ts
+++ b/src/core/pjax-worker.ts
@@ -1,5 +1,3 @@
-import { debug } from './env';
-
 /** The Pjax Web Worker class. Used to handle page revision checking & navigation requests. */
 class PjaxWorker {
     private prefetchQueue: Array<string>;
@@ -30,9 +28,7 @@ class PjaxWorker {
                 }
                 break;
             default:
-                if (debug) {
-                    console.error(`Unknown Pjax Worker message type: ${type}`);
-                }
+                console.error(`Unknown Pjax Worker message type: ${type}`);
                 break;
         }
     }


### PR DESCRIPTION
Fixes Web Workers by removing import statements, web workers as ES Modules is not supported in all browsers yet...