### PR TITLE
Closes #14 - fixes pjax page jumps

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+-   Pjax no longer attempts to prefetch external webpages
+-   Pjax no longer attepts to navigate to external webpages
+-   Pjax can handle page jumps [#14](https://github.com/Pageworks/djinnjs/issues/14)
+-   Pjax scrolls to the anchor element on page load
+
 ## [0.0.9] - 2020-01-03
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "djinnjs",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
### Fixed

-   Pjax no longer attempts to prefetch external webpages
-   Pjax no longer attepts to navigate to external webpages
-   Pjax can handle page jumps [#14](https://github.com/Pageworks/djinnjs/issues/14)
-   Pjax scrolls to the anchor element on page load