### PR TITLE
Fixed Pjaxing inline scripts

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+-   Pjax loads inline scripts [#19](https://github.com/Pageworks/djinnjs/issues/19)
+    -   Scripts with `src || id || pjax-script-id` attributes are removed and remounted every time the page loads
+    -   Scripts with `innerHTML` are remounted every time the page loads
+
 ## [0.0.11] - 2020-01-05
 
 ### Fixed

--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Pjax loads inline scripts [#19](https://github.com/Pageworks/djinnjs/issues/19)
     -   Scripts with `src || id || pjax-script-id` attributes are removed and remounted every time the page loads
     -   Scripts with `innerHTML` are remounted every time the page loads
+    -   Scripts with `src || id || pjax-script-id` attributes can prevent the remount using the `pjax-prevent-remount` attribute
 
 ## [0.0.11] - 2020-01-05
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "djinnjs",
-  "version": "0.0.9",
+  "version": "0.0.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/core/pjax.ts
+++ b/src/core/pjax.ts
@@ -423,6 +423,10 @@ class Pjax {
                 broadcaster.message('runtime', {
                     type: 'mount-components',
                 });
+                broadcaster.message('runtime', {
+                    type: 'mount-inline-scripts',
+                    selector: selector,
+                });
             });
         }
         this.removeNavigationRequest(request.requestUid);

--- a/src/core/runtime.ts
+++ b/src/core/runtime.ts
@@ -142,13 +142,20 @@ class Runtime {
                     scriptSelector += `[src="${script?.src}"]` || `#${script?.id}` || `[pjax-script-id="${script.getAttribute('pjax-script-id')}"]`;
                     const existingScript = document.head.querySelector(scriptSelector);
                     if (existingScript) {
-                        existingScript.remove();
+                        const preventRemount = script.getAttribute('pjax-prevent-remount');
+                        if (preventRemount === null) {
+                            existingScript.remove();
+                            newScript.src = script.src;
+                            document.head.appendChild(newScript);
+                        }
+                    } else {
+                        newScript.src = script.src;
+                        document.head.appendChild(newScript);
                     }
-                    newScript.src = script.src;
                 } else {
                     newScript.innerHTML = script.innerHTML;
+                    document.head.appendChild(newScript);
                 }
-                document.head.appendChild(newScript);
             });
         }
     }

--- a/src/core/runtime.ts
+++ b/src/core/runtime.ts
@@ -65,6 +65,9 @@ class Runtime {
             case 'parse':
                 this.parseHTML(data.body, data.requestUid);
                 break;
+            case 'mount-inline-scripts':
+                this.handleInlineScripts(data.selector);
+                break;
             default:
                 return;
         }
@@ -123,6 +126,30 @@ class Runtime {
                 break;
             default:
                 return;
+        }
+    }
+
+    /**
+     * Looks through the new HTML for any inline scripts and attempts to append them to the documents head.
+     */
+    private handleInlineScripts(selector: string): void {
+        const el = document.body.querySelector(selector);
+        if (el) {
+            el.querySelectorAll('script').forEach(script => {
+                const newScript = document.createElement('script');
+                if (script?.src || script?.id || script.getAttribute('pjax-script-id')) {
+                    let scriptSelector = 'script';
+                    scriptSelector += `[src="${script?.src}"]` || `#${script?.id}` || `[pjax-script-id="${script.getAttribute('pjax-script-id')}"]`;
+                    const existingScript = document.head.querySelector(scriptSelector);
+                    if (existingScript) {
+                        existingScript.remove();
+                    }
+                    newScript.src = script.src;
+                } else {
+                    newScript.innerHTML = script.innerHTML;
+                }
+                document.head.appendChild(newScript);
+            });
         }
     }
 


### PR DESCRIPTION
### Fixed

-   Pjax loads inline scripts [#19](https://github.com/Pageworks/djinnjs/issues/19)
    -   Scripts with `src || id || pjax-script-id` attributes are removed and remounted every time the page loads
    -   Scripts with `innerHTML` are remounted every time the page loads