### PR TITLE
Feature/#20 custom element prefix

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.11] - 2020-01-05
+
+### Fixed
+
+-   Content cache bust bug within the service worker
+
 ## [0.0.10] - 2020-01-05
 
 ### Fixed
@@ -143,7 +149,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     -   Base DjinnJS configuration file
     -   Intial DjinnJS compiler scripts
 
-[unreleased]: https://github.com/pageworks/djinnjs/compare/v0.0.10...HEAD
+[unreleased]: https://github.com/pageworks/djinnjs/compare/v0.0.11...HEAD
+[0.0.11]: https://github.com/pageworks/djinnjs/compare/v0.0.10...v0.0.11
 [0.0.10]: https://github.com/pageworks/djinnjs/compare/v0.0.9...v0.0.10
 [0.0.9]: https://github.com/pageworks/djinnjs/compare/v0.0.8...v0.0.9
 [0.0.8]: https://github.com/pageworks/djinnjs/compare/v0.0.7...v0.0.8

--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+-   Custom elements are prefixed with `djinnjs` [#20](https://github.com/Pageworks/djinnjs/issues/20)
+    -   `file-loading-value` is now `djinnjs-file-loading-value`
+    -   `file-loading-message` is now `djinnjs-file-loading-message`
+
 ## [0.0.11] - 2020-01-05
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "djinnjs",
-    "version": "0.0.10",
+    "version": "0.0.11",
     "description": "DjinnJS is an ES Module based JavaScript framework using JIT resource fetching, offline first content strategy, context-specific progressive enhancements, and Pjax navigation.",
     "author": "Pageworks",
     "license": "GPL-3.0",

--- a/src/core/fetch.ts
+++ b/src/core/fetch.ts
@@ -69,7 +69,7 @@ export function fetchCSS(filenames: string | Array<string>): Promise<{}> {
             resolve();
         }
 
-        const loadingMessage = document.body.querySelector('file-loading-value') || null;
+        const loadingMessage = document.body.querySelector('djinnjs-file-loading-value') || document.body.querySelector('file-loading-value') || null;
 
         let loaded = 0;
         for (let i = 0; i < resourceList.length; i++) {

--- a/src/core/fetch.ts
+++ b/src/core/fetch.ts
@@ -69,7 +69,7 @@ export function fetchCSS(filenames: string | Array<string>): Promise<{}> {
             resolve();
         }
 
-        const loadingMessage = document.body.querySelector('djinnjs-file-loading-value') || document.body.querySelector('file-loading-value') || null;
+        const loadingMessage = document.body.querySelector('djinnjs-file-loading-value') || null;
 
         let loaded = 0;
         for (let i = 0; i < resourceList.length; i++) {

--- a/src/core/runtime.ts
+++ b/src/core/runtime.ts
@@ -24,7 +24,7 @@ class Runtime {
 
     constructor() {
         this._bodyParserWorker = new Worker(`${window.location.origin}/${djinnjsOutDir}/runtime-worker.js`);
-        this._loadingMessage = document.body.querySelector('djinnjs-file-loading-message') || document.body.querySelector('file-loading-message') || null;
+        this._loadingMessage = document.body.querySelector('djinnjs-file-loading-message') || null;
         if (this._loadingMessage) {
             this._loadingMessage.setAttribute('state', '1');
         }
@@ -78,7 +78,7 @@ class Runtime {
         const response: WorkerResponse = e.data;
         switch (response.type) {
             case 'eager':
-                const loadingMessage = document.body.querySelector('djinnjs-file-loading-value') || document.body.querySelector('file-loading-value') || null;
+                const loadingMessage = document.body.querySelector('djinnjs-file-loading-value') || null;
                 if (env.domState === 'hard-loading' && this._loadingMessage) {
                     this._loadingMessage.setAttribute('state', '3');
                     this._loadingMessage.innerHTML = `Loading resources:`;

--- a/src/core/runtime.ts
+++ b/src/core/runtime.ts
@@ -24,7 +24,7 @@ class Runtime {
 
     constructor() {
         this._bodyParserWorker = new Worker(`${window.location.origin}/${djinnjsOutDir}/runtime-worker.js`);
-        this._loadingMessage = document.body.querySelector('file-loading-message') || null;
+        this._loadingMessage = document.body.querySelector('djinnjs-file-loading-message') || document.body.querySelector('file-loading-message') || null;
         if (this._loadingMessage) {
             this._loadingMessage.setAttribute('state', '1');
         }
@@ -78,7 +78,7 @@ class Runtime {
         const response: WorkerResponse = e.data;
         switch (response.type) {
             case 'eager':
-                const loadingMessage = document.body.querySelector('file-loading-value') || null;
+                const loadingMessage = document.body.querySelector('djinnjs-file-loading-value') || document.body.querySelector('file-loading-value') || null;
                 if (env.domState === 'hard-loading' && this._loadingMessage) {
                     this._loadingMessage.setAttribute('state', '3');
                     this._loadingMessage.innerHTML = `Loading resources:`;

--- a/src/core/service-worker.js
+++ b/src/core/service-worker.js
@@ -112,7 +112,7 @@ async function cachebust(url) {
         }),
     });
     if (request2.ok) {
-        const response = await request.json();
+        const response = await request2.json();
         contentCacheId = `content-${response.cacheTimestamp}`;
         caches.keys().then(cacheNames => {
             return Promise.all(


### PR DESCRIPTION
### Added

-   Custom elements are prefixed with `djinnjs` [#20](https://github.com/Pageworks/djinnjs/issues/20)
    -   `file-loading-value` is now `djinnjs-file-loading-value`
    -   `file-loading-message` is now `djinnjs-file-loading-message`