### PR TITLE
Fixed src array bug

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+-   `src` array check
+-   The scrubber and CSS util libs now synchronously resolve `src` paths when collecting files using [Glob](https://www.npmjs.com/package/glob)
+
 ## [0.0.11] - 2020-01-05
 
 ### Fixed

--- a/cli/lib/config-checker.js
+++ b/cli/lib/config-checker.js
@@ -12,7 +12,7 @@ function checkSite(site, multisite = false) {
 
         if (site.src === undefined) {
             site.src = './src';
-        } else if (typeof site.src !== 'string' && site.src instanceof Array) {
+        } else if (typeof site.src !== 'string' && !Array.isArray(site.src)) {
             reject(`Invalid DjinnJS configuration. The src value must be a string or an array of strings.`);
         }
 

--- a/cli/lib/css.js
+++ b/cli/lib/css.js
@@ -9,17 +9,13 @@ function getFiles(sources) {
         let searched = 0;
         let files = [];
         for (let i = 0; i < sources.length; i++) {
-            const dirPath = path.resolve(cwd, sources[i]);
-            glob(`${dirPath}/**/*.css`, (error, newFiles) => {
-                if (error) {
-                    reject(error);
-                }
-                files = [...files, ...newFiles];
-                searched++;
-                if (searched === sources.length) {
-                    resolve(files);
-                }
-            });
+            const dirPath = path.resolve(process.cwd(), sources[i]);
+            const newFiles = glob.sync(`${dirPath}/**/*.css`);
+            files = [...files, ...newFiles];
+            searched++;
+            if (searched === sources.length) {
+                resolve(files);
+            }
         }
     });
 }

--- a/cli/lib/scrubber.js
+++ b/cli/lib/scrubber.js
@@ -90,16 +90,12 @@ function getProjectFiles(sources) {
         let files = [];
         for (let i = 0; i < sources.length; i++) {
             const dirPath = path.resolve(process.cwd(), sources[i]);
-            glob(`${dirPath}/**/*.js`, (error, newFiles) => {
-                if (error) {
-                    reject(error);
-                }
-                files = [...newFiles];
-                searched++;
-                if (searched === sources.length) {
-                    resolve(files);
-                }
-            });
+            const newFiles = glob.sync(`${dirPath}/**/*.js`);
+            files = [...files, ...newFiles];
+            searched++;
+            if (searched === sources.length) {
+                resolve(files);
+            }
         }
     });
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "djinnjs",
-  "version": "0.0.9",
+  "version": "0.0.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
### Fixed

-   `src` array check
-   The scrubber and CSS util libs now synchronously resolve `src` paths when collecting files using [Glob](https://www.npmjs.com/package/glob)