### PR TITLE
Fixed disableServiceWorker bug

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+-   when `disableServiceWorker` is `true` Pjax no longer attempts to register any service worker scripts
+
 ## [0.0.13] - 2020-01-10
 
 ### Fixed

--- a/cli/cli.js
+++ b/cli/cli.js
@@ -296,6 +296,7 @@ class DjinnJS {
                     data = data.replace('"REPLACE_WITH_PJAX_STATUS"', this.sites[i].disablePjax);
                     data = data.replace('"REPLACE_WITH_PREFETCH_STATUS"', this.sites[i].disablePrefetching);
                     data = data.replace('"REPLACE_WITH_USE_PERCENTAGE"', this.sites[i].usePercentage);
+                    data = data.replace('"REPLACE_WITH_USE_SERVICE_WORKER"', this.sites[i].disableServiceWorker);
                     fs.writeFile(runtimeFile, data, error => {
                         if (error) {
                             reject(error);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "djinnjs",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -5,3 +5,4 @@ export const defaultTransition = "REPLACE_WITH_DEFAULT_TRANSITION";
 export const disablePjax = "REPLACE_WITH_PJAX_STATUS";
 export const disablePrefetching = "REPLACE_WITH_PREFETCH_STATUS";
 export const usePercentage = "REPLACE_WITH_USE_PERCENTAGE";
+export const disableServiceWorker = "REPLACE_WITH_USE_SERVICE_WORKER";

--- a/src/core/pjax.ts
+++ b/src/core/pjax.ts
@@ -2,7 +2,7 @@ import { broadcaster } from "./broadcaster";
 import { debug, env, uuid } from "./env";
 import { sendPageView, setupGoogleAnalytics } from "./gtags.js";
 import { transitionManager } from "./transition-manager";
-import { djinnjsOutDir, gaId, disablePrefetching } from "./config";
+import { djinnjsOutDir, gaId, disablePrefetching, disableServiceWorker } from "./config";
 import { notify } from "../web_modules/@codewithkyle/notifications";
 import { fetchCSS } from "./fetch";
 
@@ -63,7 +63,7 @@ class Pjax {
         this.worker.onmessage = this.handleWorkerMessage.bind(this);
 
         /** Attempt to register a service worker */
-        if ("serviceWorker" in navigator) {
+        if ("serviceWorker" in navigator && !disableServiceWorker) {
             navigator.serviceWorker
                 .register(`${window.location.origin}/service-worker.js`, { scope: "/" })
                 .then(() => {


### PR DESCRIPTION
### Fixed

-   when `disableServiceWorker` is `true` Pjax no longer attempts to register any service worker scripts