### PR TITLE
Hotfix - Pjax view verification

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+-   Pjax verifies views exists before swapping [#30](https://github.com/Pageworks/djinnjs/issues/30)
+-   Pjax uses `pjax-id` attribute to verify the developer intended for the `<main>` elements match
+
 ## [0.0.13] - 2020-01-10
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "djinnjs",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
### Fixed

-   Pjax verifies views exists before swapping [#30](https://github.com/Pageworks/djinnjs/issues/30)
-   Pjax uses `pjax-id` attribute to verify the developer intended for the `<main>` elements to match