### PR TITLE
Hotfix - #39 pjax page jumps

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Windows filename regex issues [#28](https://github.com/Pageworks/djinnjs/issues/28)
 -   `fetchJS()` bug where `.js` was appended to external URLs [#35](https://github.com/Pageworks/djinnjs/issues/35)
 -   script scrubber regex issue [#40](https://github.com/Pageworks/djinnjs/issues/40)
+-   Updated Pjax page jump logic to use `id` attribute instead of the obsolute `name` attribute [#39](https://github.com/Pageworks/djinnjs/issues/39)
 
 ## [0.0.14] - 2020-01-13
 

--- a/changelog.md
+++ b/changelog.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Windows filename regex issues [#28](https://github.com/Pageworks/djinnjs/issues/28)
 -   `fetchJS()` bug where `.js` was appended to external URLs [#35](https://github.com/Pageworks/djinnjs/issues/35)
 -   script scrubber regex issue [#40](https://github.com/Pageworks/djinnjs/issues/40)
--   Updated Pjax page jump logic to use `id` attribute instead of the obsolute `name` attribute [#39](https://github.com/Pageworks/djinnjs/issues/39)
+-   Updated Pjax page jump logic to use `id` attribute instead of the obsolete `name` attribute [#39](https://github.com/Pageworks/djinnjs/issues/39)
 
 ## [0.0.14] - 2020-01-13
 

--- a/src/core/pjax.ts
+++ b/src/core/pjax.ts
@@ -114,7 +114,7 @@ class Pjax {
             case "finalize-pjax":
                 this.updateHistory(data.title, data.url, data.history);
                 if (new RegExp("#").test(data.url)) {
-                    this.scrollToAnchor(data.url);
+                    this.scrollToHash(data.url);
                 }
                 this.collectLinks();
                 this.checkPageRevision();
@@ -227,10 +227,12 @@ class Pjax {
         }
     }
 
-    private scrollToAnchor(url: string): void {
-        const anchor = document.body.querySelector(`a[name="${url.match(/\#.*/g)[0].replace("#", "")}"]`);
-        if (anchor) {
-            anchor.scrollIntoView();
+    private scrollToHash(url: string): void {
+        const hash = url.match(/\#.*/)[0];
+        const element = document.body.querySelector(hash);
+        if (element) {
+            element.scrollIntoView();
+            return;
         }
     }
 


### PR DESCRIPTION
### Fixed

-   Updated Pjax page jump logic to use `id` attribute instead of the obsolete `name` attribute [#39](https://github.com/Pageworks/djinnjs/issues/39)