### PR TITLE
Fixed mjs file extension for production builds

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+-   incorrect file extensions for production builds
+-   service worker is removed from the `outDir` when disabled
+
 ## [0.0.20] - 2020-02-04
 
 ### Fixed

--- a/cli/cli.js
+++ b/cli/cli.js
@@ -238,7 +238,7 @@ class DjinnJS {
                 const publicPath = path.resolve(cwd, this.sites[i].publicDir);
                 const assetPath = path.resolve(publicPath, this.sites[i].outDir);
                 if (this.sites[i].disableServiceWorker) {
-                    fs.unlink(`${assetPath}/service-worker.js`, error => {
+                    fs.unlink(`${assetPath}/service-worker.mjs`, error => {
                         if (error) {
                             reject(error);
                         }

--- a/cli/lib/minifier.js
+++ b/cli/lib/minifier.js
@@ -23,7 +23,7 @@ function minifyFiles(files, publicDir, relativeOutDir) {
         let minified = 0;
         const outDir = path.resolve(cwd, publicDir, relativeOutDir);
         for (let i = 0; i < files.length; i++) {
-            const filename = files[i].replace(/.*[\/\\]/g, "");
+            const filename = files[i].replace(/(.*[\/\\])|(\..*)$/g, "");
             fs.readFile(files[i], (error, buffer) => {
                 if (error) {
                     reject(error);
@@ -42,7 +42,7 @@ function minifyFiles(files, publicDir, relativeOutDir) {
                 if (result.error) {
                     reject(`Terser Error: ${result.error.message} occured in ${filename}`);
                 }
-                fs.writeFile(`${outDir}/${filename}`, result.code, error => {
+                fs.writeFile(`${outDir}/${filename}.mjs`, result.code, error => {
                     if (error) {
                         reject(error);
                     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "djinnjs",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
### Fixed

-   incorrect file extensions for production builds
-   service worker is removed from the `outDir` when disabled