### PR TITLE
Closes #61 - adds ability to prevent pjax from following redirects

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+-   ability to disable redirect following when pjaxing pages using the `followRedirects` config variable [#61](https://github.com/Pageworks/djinnjs/issues/61)
+
+### Fixed
+
+-   changed the service worker no-cache passthrough
+
 ## [0.0.23] - 2020-03-29
 
 ### ⚠️ Breaking Changes ⚠️

--- a/cli/cli.js
+++ b/cli/cli.js
@@ -310,6 +310,7 @@ class DjinnJS {
                     data = data.replace("REPLACE_WITH_DEFAULT_TRANSITION", this.sites[i].defaultTransition);
                     data = data.replace('"REPLACE_WITH_PJAX_STATUS"', this.sites[i].disablePjax);
                     data = data.replace('"REPLACE_WITH_PREFETCH_STATUS"', this.sites[i].disablePrefetching);
+                    data = data.replace('"REPLACE_WITH_FOLLOW_REDIRECT_STATUS"', this.sites[i].followRedirects);
                     data = data.replace('"REPLACE_WITH_USE_PERCENTAGE"', this.sites[i].usePercentage);
                     data = data.replace('"REPLACE_WITH_USE_SERVICE_WORKER"', this.sites[i].disableServiceWorker);
                     fs.writeFile(runtimeFile, data, error => {

--- a/cli/lib/config-checker.js
+++ b/cli/lib/config-checker.js
@@ -1,32 +1,32 @@
-const yargs = require('yargs').argv;
+const yargs = require("yargs").argv;
 
 function checkSite(site, multisite = false) {
     return new Promise((resolve, reject) => {
         if (multisite) {
             if (site.handle === undefined) {
                 reject(`Invalid DjinnJS configuration. Sites require a handle when running DjinnJS in multisite mode.`);
-            } else if (typeof site.handle !== 'string') {
+            } else if (typeof site.handle !== "string") {
                 reject(`Invalid DjinnJS configuration. The handle value must be a string.`);
             }
         }
 
         if (site.src === undefined) {
-            site.src = './src';
-        } else if (typeof site.src !== 'string' && !Array.isArray(site.src)) {
+            site.src = "./src";
+        } else if (typeof site.src !== "string" && !Array.isArray(site.src)) {
             reject(`Invalid DjinnJS configuration. The src value must be a string or an array of strings.`);
         }
 
         if (site.publicDir === undefined) {
-            site.publicDir = './public';
-        } else if (typeof site.publicDir !== 'string') {
+            site.publicDir = "./public";
+        } else if (typeof site.publicDir !== "string") {
             reject(`Invalid DjinnJS configuration. The publicDir value must be a string.`);
         } else {
             site.publicDir = site.publicDir.trim();
         }
 
         if (site.outDir === undefined) {
-            site.outDir = 'assets';
-        } else if (typeof site.outDir !== 'string') {
+            site.outDir = "assets";
+        } else if (typeof site.outDir !== "string") {
             reject(`Invalid DjinnJS configuration. The outDir value must be a string.`);
         } else {
             site.outDir = site.outDir.toLowerCase().trim();
@@ -34,45 +34,51 @@ function checkSite(site, multisite = false) {
 
         if (site.disableServiceWorker === undefined) {
             site.disableServiceWorker = false;
-        } else if (typeof site.disableServiceWorker !== 'boolean') {
+        } else if (typeof site.disableServiceWorker !== "boolean") {
             reject(`Invalid DjinnJS configuration. The disableServiceWorker value must be a boolean.`);
         }
 
         if (site.gtagId === undefined) {
-            site.gtagId = '';
-        } else if (typeof site.gtagId !== 'string') {
+            site.gtagId = "";
+        } else if (typeof site.gtagId !== "string") {
             reject(`Invalid DjinnJS configuration. The gtagId value must be a string.`);
         }
 
         if (site.defaultTransition === undefined) {
-            site.defaultTransition = 'fade';
-        } else if (typeof site.defaultTransition !== 'string') {
+            site.defaultTransition = "fade";
+        } else if (typeof site.defaultTransition !== "string") {
             reject(`Invalid DjinnJS configuration. The defaultTransition value must be a string.`);
         }
 
         if (site.disablePjax === undefined) {
             site.disablePjax = false;
-        } else if (typeof site.disablePjax !== 'boolean') {
+        } else if (typeof site.disablePjax !== "boolean") {
             reject(`Invalid DjinnJS configuration. The disablePjax value must be a boolean.`);
+        }
+
+        if (site.followRedirects === undefined) {
+            site.followRedirects = true;
+        } else if (typeof site.followRedirects !== "boolean") {
+            reject(`Invalid DjinnJS configuration. The followRedirects value must be a boolean.`);
         }
 
         if (site.disablePrefetching === undefined) {
             site.disablePrefetching = false;
-        } else if (typeof site.disablePrefetching !== 'boolean') {
+        } else if (typeof site.disablePrefetching !== "boolean") {
             reject(`Invalid DjinnJS configuration. The disablePrefetching value must be a boolean.`);
         }
 
         if (site.usePercentage === undefined) {
             site.usePercentage = false;
-        } else if (typeof site.usePercentage !== 'boolean') {
+        } else if (typeof site.usePercentage !== "boolean") {
             reject(`Invalid DjinnJS configuration. The usePercentage value must be a boolean.`);
         }
 
         let env = site.env || yargs.e || yargs.env;
         if (!env) {
-            env = 'production';
+            env = "production";
         }
-        if (typeof env !== 'string') {
+        if (typeof env !== "string") {
             reject(`Invalid DjinnJS configuration. The env value must be a string.`);
         }
         site.env = env.toLowerCase().trim();

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -4,5 +4,6 @@ export const environment = "REPLACE_WITH_ENVIRONMENT";
 export const defaultTransition = "REPLACE_WITH_DEFAULT_TRANSITION";
 export const disablePjax = "REPLACE_WITH_PJAX_STATUS";
 export const disablePrefetching = "REPLACE_WITH_PREFETCH_STATUS";
+export const followRedirects = "REPLACE_WITH_FOLLOW_REDIRECT_STATUS";
 export const usePercentage = "REPLACE_WITH_USE_PERCENTAGE";
 export const disableServiceWorker = "REPLACE_WITH_USE_SERVICE_WORKER";

--- a/src/core/pjax.ts
+++ b/src/core/pjax.ts
@@ -2,7 +2,7 @@ import { hookup, message } from "../web_modules/broadcaster";
 import { debug, env, uuid } from "./env";
 import { sendPageView, setupGoogleAnalytics } from "./gtags.js";
 import { transitionManager } from "./transition-manager";
-import { djinnjsOutDir, gaId, disablePrefetching, disableServiceWorker } from "./config";
+import { djinnjsOutDir, gaId, disablePrefetching, disableServiceWorker, followRedirects } from "./config";
 import { notify } from "../web_modules/@codewithkyle/notifications";
 import { fetchCSS } from "./fetch";
 
@@ -271,6 +271,7 @@ class Pjax {
             requestId: requestUid,
             url: url,
             currentUrl: location.href,
+            followRedirects: followRedirects,
         });
     }
 

--- a/src/core/service-worker.js
+++ b/src/core/service-worker.js
@@ -6,13 +6,8 @@ let contentCacheId = "content-initial";
 self.addEventListener("fetch", event => {
     const noCache = event.request.url.match(new RegExp(REPLACE_WITH_NO_CACHE_PATTERN));
     if (noCache || event.request.method !== "GET") {
-        event.respondWith(
-            fetch(event.request, {
-                redirect: "follow",
-            }).then(response => {
-                return response;
-            })
-        );
+        // Use a passthrough to ignore the caching system
+        event.respondWith(fetch(event.request));
     } else {
         const isResource = event.request.url.match(/(\.js)$|(\.css)$|(\.mjs)$|(\.cjs)$/gi);
         const cacheName = isResource ? resourcesCacheId : contentCacheId;
@@ -25,6 +20,7 @@ self.addEventListener("fetch", event => {
 
                 return fetch(event.request, {
                     redirect: "follow",
+                    credentials: "include",
                 }).then(response => {
                     if (!response || response.status !== 200 || response.type !== "basic" || response.headers.get("PWA-Cache") === "no-cache" || response.redirected) {
                         return response;


### PR DESCRIPTION
### Added

-   ability to disable redirect following when pjaxing pages using the `followRedirects` config variable [#61](https://github.com/Pageworks/djinnjs/issues/61)

### Fixed

-   changed the service worker no-cache passthrough