### PR TITLE
Added support for multiview hotswapping during Pjax page transitions

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+-   added the ability to swap multiple views during a page transition
+-   added `<body>` fallback when no `pjax-id` attributes or a `<main>` element isn't available
+
 ## [0.1.2] - 2020-07-18
 
 ### Fixed

--- a/src/core/djinn-utils.ts
+++ b/src/core/djinn-utils.ts
@@ -1,10 +1,13 @@
 /**
  * Looks through the new HTML for any inline scripts and attempts to append them to the documents head.
  */
-export function handleInlineScripts(selector: string): void {
-    const el = document.body.querySelector(selector);
-    if (el) {
-        el.querySelectorAll("script").forEach(script => {
+export function handleInlineScripts(selectors: Array<string>): void {
+    const views = [];
+    for (let i = 0; i < selectors.length; i++) {
+        views.push(document.documentElement.querySelector(selectors[i]));
+    }
+    for (let i = 0; i < views.length; i++) {
+        views[i].querySelectorAll("script").forEach(script => {
             const newScript = document.createElement("script");
             newScript.type = script.type;
             newScript.noModule = script.noModule;

--- a/src/core/dynamic-runtime.ts
+++ b/src/core/dynamic-runtime.ts
@@ -50,7 +50,7 @@ class Djinn {
                 webComponentManager.collectWebComponents();
                 break;
             case "mount-inline-scripts":
-                this.mountInlineScripts(data.selector);
+                this.mountInlineScripts(data.selectors);
                 break;
             case "parse":
                 this.loadCSS(data.body, data.requestUid);
@@ -60,9 +60,9 @@ class Djinn {
         }
     }
 
-    private async mountInlineScripts(selector) {
+    private async mountInlineScripts(selectors) {
         const module = await import(`${location.origin}/${djinnjsOutDir}/djinn-utils.mjs`);
-        module.handleInlineScripts(selector);
+        module.handleInlineScripts(selectors);
     }
 
     private async handlePjaxResponse(data: PjaxResources, requestUid: string) {

--- a/src/core/pjax.ts
+++ b/src/core/pjax.ts
@@ -394,38 +394,70 @@ class Pjax {
     private swapPjaxContent(requestUid: string) {
         const request = this.getNavigaitonRequest(requestUid);
         if (request.requestUid === this.state.activeRequestUid) {
-            let selector;
-            let currentMain: HTMLElement;
+            let selectors: Array<string> = [];
+            let currentViews: Array<HTMLElement> = [];
             if (request.targetSelector !== null) {
-                selector = `[pjax-id="${request.targetSelector}"]`;
-                currentMain = document.body.querySelector(selector);
+                selectors = [`[pjax-id="${request.targetSelector}"]`];
+                const currentView = document.documentElement.querySelector(selectors[0]);
+                if (!currentView) {
+                    console.error(`${location.href} is missing selector ${selectors[0]}`);
+                    window.location.href = request.url;
+                    return;
+                }
             } else {
-                selector = "main";
-                currentMain = document.body.querySelector(selector);
-                const mainId = currentMain.getAttribute("pjax-id");
-                if (mainId) {
-                    selector = `[pjax-id="${mainId}"]`;
+                currentViews = Array.from(document.documentElement.querySelectorAll("[pjax-id]"));
+                if (currentViews.length) {
+                    for (let i = 0; i < currentViews.length; i++) {
+                        selectors.push(`[pjax-id="${currentViews[i].getAttribute("pjax-id")}"]`);
+                    }
+                } else {
+                    const main = document.documentElement.querySelector("main");
+                    if (main) {
+                        selectors = ["main"];
+                        currentViews.push(main);
+                    } else {
+                        selectors = ["body"];
+                        currentViews.push(document.body);
+                    }
                 }
             }
 
-            if (!currentMain) {
-                console.error(`${location.href} is missing selector ${selector}`);
-                window.location.href = request.url;
-                return;
+            for (let i = 0; i < currentViews.length; i++) {
+                currentViews[i].innerHTML = "";
             }
 
-            currentMain.innerHTML = "";
             const tempDocument: HTMLDocument = document.implementation.createHTMLDocument("pjax-temp-document");
             tempDocument.documentElement.innerHTML = request.body;
-            const incomingMain = tempDocument.querySelector(selector) as HTMLElement;
 
-            if (!incomingMain) {
-                console.error(`New page is missing selector ${selector}`);
+            const newViews: Array<HTMLElement> = [];
+            for (let i = 0; i < selectors.length; i++) {
+                const newView = tempDocument.documentElement.querySelector(selectors[i]) as HTMLElement;
+                if (newView) {
+                    newViews.push(newView);
+                } else {
+                    console.error(`${request.url} is missing selector ${selectors[i]}`);
+                    window.location.href = request.url;
+                    return;
+                }
+            }
+
+            if (newViews.length !== currentViews.length) {
+                console.error(`Something went wrong when collecting the views`);
                 window.location.href = request.url;
                 return;
             }
 
-            currentMain.innerHTML = incomingMain.innerHTML;
+            for (let i = 0; i < currentViews.length; i++) {
+                for (let k = 0; k < newViews.length; k++) {
+                    // This will work for body and main elements because the attribute will return null for both
+                    // Since there is only 1 view in the queue when swapping the main or body we are OK to assume they're the same view
+                    if (currentViews[i].getAttribute("pjax-id") === newViews[k].getAttribute("pjax-id")) {
+                        currentViews[i].innerHTML = newViews[k].innerHTML;
+                        break;
+                    }
+                }
+            }
+
             document.title = tempDocument.title;
 
             window.scroll({
@@ -456,7 +488,7 @@ class Pjax {
                 recipient: "runtime",
                 type: "mount-inline-scripts",
                 data: {
-                    selector: selector,
+                    selectors: selectors,
                 },
             });
 

--- a/src/core/runtime.ts
+++ b/src/core/runtime.ts
@@ -68,7 +68,7 @@ class Runtime {
                 this.parseHTML(data.body, data.requestUid);
                 break;
             case "mount-inline-scripts":
-                this.handleInlineScripts(data.selector);
+                this.handleInlineScripts(data.selectors);
                 break;
             default:
                 return;
@@ -177,10 +177,13 @@ class Runtime {
     /**
      * Looks through the new HTML for any inline scripts and attempts to append them to the documents head.
      */
-    private handleInlineScripts(selector: string): void {
-        const el = document.body.querySelector(selector);
-        if (el) {
-            el.querySelectorAll("script").forEach(script => {
+    private handleInlineScripts(selectors: Array<string>): void {
+        const views = [];
+        for (let i = 0; i < selectors.length; i++) {
+            views.push(document.documentElement.querySelector(selectors[i]));
+        }
+        for (let i = 0; i < views.length; i++) {
+            views[i].querySelectorAll("script").forEach(script => {
                 const newScript = document.createElement("script");
                 newScript.type = script.type;
                 newScript.noModule = script.noModule;


### PR DESCRIPTION
### Added

-   added the ability to swap multiple views during a page transition
-   added `<body>` fallback when no `pjax-id` attributes or a `<main>` element isn't available

### Note

This feature was removed when Pjax was refactored. I need this feature again in order to hotswap inline CSS from the documents `<head>` during page transitions.